### PR TITLE
멀티렌더타겟 생성 추가

### DIFF
--- a/Engine_SOURCE/Engine_SOURCE.vcxproj
+++ b/Engine_SOURCE/Engine_SOURCE.vcxproj
@@ -248,6 +248,7 @@ copy "$(SolutionDir)PhysXFoundation_64.dll" "$(SolutionDir)\x64\Debug\"</Command
     <ClInclude Include="Material.h" />
     <ClInclude Include="Mesh.h" />
     <ClInclude Include="MeshRenderer.h" />
+    <ClInclude Include="MultiRenderTarget.h" />
     <ClInclude Include="Object.h" />
     <ClInclude Include="PaintShader.h" />
     <ClInclude Include="ParticleShader.h" />
@@ -338,6 +339,7 @@ copy "$(SolutionDir)PhysXFoundation_64.dll" "$(SolutionDir)\x64\Debug\"</Command
     <ClCompile Include="Material.cpp" />
     <ClCompile Include="Mesh.cpp" />
     <ClCompile Include="MeshRenderer.cpp" />
+    <ClCompile Include="MultiRenderTarget.cpp" />
     <ClCompile Include="PaintShader.cpp" />
     <ClCompile Include="ParticleShader.cpp" />
     <ClCompile Include="ParticleSystem.cpp" />

--- a/Engine_SOURCE/Engine_SOURCE.vcxproj.filters
+++ b/Engine_SOURCE/Engine_SOURCE.vcxproj.filters
@@ -481,6 +481,9 @@
     <ClInclude Include="ApplyPacketScript.h">
       <Filter>Common\Component\Script\Server</Filter>
     </ClInclude>
+    <ClInclude Include="MultiRenderTarget.h">
+      <Filter>Graphics</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Application.cpp">
@@ -733,6 +736,9 @@
     </ClCompile>
     <ClCompile Include="ApplyPacketScript.cpp">
       <Filter>Common\Component\Script\Server</Filter>
+    </ClCompile>
+    <ClCompile Include="MultiRenderTarget.cpp">
+      <Filter>Graphics</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Engine_SOURCE/GraphicDevice.cpp
+++ b/Engine_SOURCE/GraphicDevice.cpp
@@ -82,8 +82,8 @@ GraphicDevice::GraphicDevice(eValidationMode _ValidationMode)
 
 	mDepthStencilBufferTexture =  new Texture();
 	mDepthStencilBufferTexture->Create(1600, 900, DXGI_FORMAT::DXGI_FORMAT_D24_UNORM_S8_UINT, D3D11_BIND_FLAG::D3D11_BIND_DEPTH_STENCIL);
-	
 	GETSINGLE(ResourceMgr)->Insert<Texture>(L"DepthStencilBufferTexture", mDepthStencilBufferTexture);
+	
 	// Setting Viewport		
 	RECT winRect;
 	GetClientRect(application.GetHwnd(), &winRect);
@@ -481,6 +481,11 @@ void GraphicDevice::OMSetRenderTarget()
 	mContext->OMSetRenderTargets(1
 		, mRenderTargetTexture->GetRTV().GetAddressOf()
 		, mDepthStencilBufferTexture->GetDSV().Get());
+}
+
+void GraphicDevice::OMSetRenderTarget(UINT numViews, ID3D11RenderTargetView** renderTargetViews, ID3D11DepthStencilView* depthStencilView)
+{
+	mContext->OMSetRenderTargets(numViews, renderTargetViews, depthStencilView);
 }
 
 void GraphicDevice::Draw()

--- a/Engine_SOURCE/GraphicDevice.h
+++ b/Engine_SOURCE/GraphicDevice.h
@@ -66,6 +66,7 @@ public:
 	void Clear();
 	void AdjustViewPorts();
 	void OMSetRenderTarget();
+	void OMSetRenderTarget(UINT numViews, ID3D11RenderTargetView** renderTargetViews, ID3D11DepthStencilView* depthStencilView);
 
 	void Draw();
 	void DrawIndexed(UINT indexCount, UINT startIndexLocation, INT baseVertexLocation);

--- a/Engine_SOURCE/Graphics.h
+++ b/Engine_SOURCE/Graphics.h
@@ -30,7 +30,6 @@
 #define CBSLOT_LASERHIT			9
 
 
-
 enum class eValidationMode
 {
 	Disabled,
@@ -94,8 +93,20 @@ enum class eBlendStateType
 	End,
 };
 
+enum class eRenderTargetType
+{
+	Swapchain,
+	Deferred,
+	Light,
+	Shadow,
+	End,
+};
+
 enum class eRenderingMode
 {
+	DeferredOpaque, // 불투명
+	DeferredMask,
+	Light, // 광원 처리
 	Opaque, // 불투명
 	Cutout, // 일부만 투명
 	Transparent,

--- a/Engine_SOURCE/MultiRenderTarget.cpp
+++ b/Engine_SOURCE/MultiRenderTarget.cpp
@@ -1,0 +1,49 @@
+#include "MultiRenderTarget.h"
+
+MultiRenderTarget::MultiRenderTarget()
+	: mRenderTargets{}
+	, mDSTexture(nullptr)
+	, mRenderTargetCount(0)
+{
+}
+
+MultiRenderTarget::~MultiRenderTarget()
+{
+}
+
+void MultiRenderTarget::Create(Texture* texture[8], Texture* dsTexture)
+{
+	for (size_t i = 0; i < 8; i++)
+	{
+		if (texture[i] == nullptr)
+		{
+			mRenderTargetCount = i;
+			break;
+		}
+
+		mRenderTargets[i] = texture[i];
+	}
+
+	mDSTexture = dsTexture;
+}
+
+void MultiRenderTarget::OMSetRenderTarget()
+{
+	ID3D11RenderTargetView* arrRenderTargetViews[8] = {};
+	for (size_t i = 0; i < 8; i++)
+	{
+		if (mRenderTargets[i])
+		{
+			arrRenderTargetViews[i] = mRenderTargets[i]->GetRTV().Get();
+		}
+	}
+
+	if (mDSTexture != nullptr)
+	{
+		GetDevice()->OMSetRenderTarget(mRenderTargetCount, arrRenderTargetViews, mDSTexture->GetDSV().Get());
+	}
+	else
+	{
+		GetDevice()->OMSetRenderTarget(mRenderTargetCount, arrRenderTargetViews, nullptr);
+	}
+}

--- a/Engine_SOURCE/MultiRenderTarget.h
+++ b/Engine_SOURCE/MultiRenderTarget.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Entity.h"
+#include "Texture.h"
+
+class MultiRenderTarget : public Entity
+{
+public:
+	MultiRenderTarget();
+	~MultiRenderTarget();
+
+	void Create(Texture* texture[8], Texture* dsTexture);
+	void OMSetRenderTarget();
+
+private:
+	Texture* mRenderTargets[8];
+	Texture* mDSTexture;
+	UINT mRenderTargetCount;
+};
+

--- a/Engine_SOURCE/Renderer.h
+++ b/Engine_SOURCE/Renderer.h
@@ -9,6 +9,7 @@
 #include "Camera.h"
 #include "Light.h"
 #include "StructedBuffer.h"
+#include "MultiRenderTarget.h"
 
 using namespace math;
 
@@ -196,7 +197,8 @@ namespace renderer
 	extern StructedBuffer* lightBuffer;
 
 	extern GameObj* inspectorGameObject;
-
+	
+	extern MultiRenderTarget* renderTargets[]; //MultiRenderTargets
 
 	void Initialize();
 	void release(); // 그리는 방식이 여러개일때 여러개를 할당하는게 아니라
@@ -205,6 +207,7 @@ namespace renderer
 	
 	void Render();
 
+	void CreateRenderTargets(); //MultiRenderTargets
 	void PushLightAttribute(LightAttribute attribute);
 	void BindLight();
 	void BindNoiseTexture();

--- a/Engine_SOURCE/Texture.cpp
+++ b/Engine_SOURCE/Texture.cpp
@@ -79,6 +79,12 @@ bool Texture::Create(UINT width, UINT height, DXGI_FORMAT format, UINT bindflag)
 			return false;
 		}
 	}
+	if (bindflag & D3D11_BIND_FLAG::D3D11_BIND_RENDER_TARGET)
+	{
+		if (!GetDevice()->CreateRenderTargetView(mTexture.Get(), nullptr, mRTV.GetAddressOf()))
+			return false;
+	}
+
 
 	return true;
 }


### PR DESCRIPTION
0721 멀티렌더타겟 생성 추가
//작동이 안되거나 잘못된 부분있으면 말씀해주세요
Graphics.h에 enum class eRenderTargetType 추가

enum class eRenderingMode에 멤버 DeferredOpaque, DeferredMask, Light, 추가 

Engine_SOURCE/Graphics/MultiRenderTarget 클래스 추가

Renderer::Initialize() 실행시 CreateRenderTarget() 추가