### PR TITLE
같은 모델을 공유하는 여러 객체의 각자 다른 애니메이션을 사용할수 없었던 버그를 수정하였습니다.

### DIFF
--- a/Engine_SOURCE/AnimationClip.cpp
+++ b/Engine_SOURCE/AnimationClip.cpp
@@ -216,6 +216,9 @@ void AnimationClip::SetBoneMatrix(const animation::SkeletonData& inCurData, cons
 
 		// T * R
 		node->SetTransformation(ToLeftHandMatrix(positionVec, result.GetMatrix()));
+
+		// 애니메이터의 현재 이동정보들을 세팅해줄거다
+		mAnimator->AddNodeTransform(mNodeData[curData.Translation[i].first].Name, ToLeftHandMatrix(positionVec, result.GetMatrix()));
 	}
 }
 
@@ -343,7 +346,7 @@ const animation::NodeData AnimationClip::readNodes(std::string& buf) const
 	fPos += 1;
 
 	str = buf.substr(fPos, lPos - fPos);
-	Data.Name = ConvertToW_String(str.c_str());
+	Data.Name = L"Armature_" + ConvertToW_String(str.c_str());
 
 
 	fPos = buf.find_last_of(' ', buf.size() - 1);

--- a/Engine_SOURCE/BoneAnimator.cpp
+++ b/Engine_SOURCE/BoneAnimator.cpp
@@ -43,6 +43,7 @@ void BoneAnimator::Update()
 		mPlayAnimation->SetCurIndex(0);
 	}
 
+	mFrameAnimationVector.clear();
 	mPlayAnimation->Update();
 }
 
@@ -169,4 +170,31 @@ AnimationClip* BoneAnimator::GetAnimationClip(const std::wstring& animationName)
 		return nullptr;
 
 	return iter->second;
+}
+
+aiMatrix4x4 BoneAnimator::GetAnimationNodeTransform(const std::wstring& name) const
+{
+	auto iter = mFrameAnimationVector.find(name);
+	if (iter == mFrameAnimationVector.end())
+		return aiMatrix4x4();
+
+	return iter->second;
+}
+
+void BoneAnimator::AddNodeTransform(const std::wstring& name, aiMatrix4x4 transform)
+{
+	auto iter = mFrameAnimationVector.find(name);
+	if (iter != mFrameAnimationVector.end())
+		iter->second = transform;
+	else
+		mFrameAnimationVector.insert(std::pair(name, transform));
+}
+
+void BoneAnimator::DeleteNodeTransform(const std::wstring& name)
+{
+	auto iter = mFrameAnimationVector.find(name);
+	if (iter == mFrameAnimationVector.end())
+		return;
+
+	mFrameAnimationVector.erase(iter);
 }

--- a/Engine_SOURCE/BoneAnimator.h
+++ b/Engine_SOURCE/BoneAnimator.h
@@ -3,6 +3,13 @@
 #include "AnimationClip.h"
 #include "Struct.h"
 
+#include "..//External/assimp/include/assimp/Importer.hpp"
+#include "..//External/assimp/include/assimp/cimport.h"
+#include "..//External/assimp/include/assimp/postprocess.h"
+#include "..//External/assimp/include/assimp/scene.h"
+
+#pragma comment(lib, "..//External/assimp/lib/Debug/assimp-vc143-mtd.lib")
+
 class BoneAnimator : public Component
 {
 public:
@@ -27,18 +34,25 @@ public:
 
 	// 애니메이션의 1 프레임 간격 세팅
 	void SetAnimationDruationTime(const std::wstring& name, float duration = 0.1f);
-
 	bool IsComplete() { return mPlayAnimation == nullptr ? true :mPlayAnimation->IsComplete(); }
-
 	const std::wstring PlayAnimationName() const;
-
 	AnimationClip* GetAnimationClip(const std::wstring& animationName) const;
+
+	const std::map<std::wstring, aiMatrix4x4>& GetFrameAnimationData() { return mFrameAnimationVector; }
+	aiMatrix4x4 GetAnimationNodeTransform(const std::wstring& name) const ;
+	void AddNodeTransform(const std::wstring& name, aiMatrix4x4 transform);
+	void DeleteNodeTransform(const std::wstring& name);
+
 public:
 	GETSET(float, mIntervalAnimation, IntervalAnimation)
 private:
+	// 애니메이션들을 담을곳
 	std::map<std::wstring, AnimationClip*> mAnimationClips;
 	AnimationClip* mPlayAnimation;
 
+	// 1 프레임의 애니메이션 이동정보를 담을곳
+	std::map<std::wstring, aiMatrix4x4> mFrameAnimationVector;
+	
 	float mIntervalAnimation;
 	bool mbLoop;
 };

--- a/Engine_SOURCE/MarioCap.cpp
+++ b/Engine_SOURCE/MarioCap.cpp
@@ -76,8 +76,9 @@ void MarioCap::Initialize()
 	Physicalinit();
 
 
-
 	DynamicObject::Initialize();
+
+	GetComponent<MeshRenderer>()->SetBoneAnimator(nullptr);
 }
 
 void MarioCap::Update()

--- a/Engine_SOURCE/MarioParts.cpp
+++ b/Engine_SOURCE/MarioParts.cpp
@@ -33,6 +33,8 @@ void MarioParts::Initialize()
 
 	BoneInitialize();
 	DynamicObject::Initialize();
+
+	GetComponent<MeshRenderer>()->SetBoneAnimator(nullptr);
 }
 
 void MarioParts::Update()

--- a/Engine_SOURCE/MeshRenderer.cpp
+++ b/Engine_SOURCE/MeshRenderer.cpp
@@ -3,11 +3,13 @@
 #include "Transform.h"
 #include "Model.h"
 #include "Mesh.h"
+#include "BoneAnimator.h"
 
 
 
 MeshRenderer::MeshRenderer()
 	: BaseRenderer(eComponentType::MeshRenderer)
+	, mBoneAnimator(nullptr)
 {
 }
 
@@ -18,6 +20,11 @@ MeshRenderer::~MeshRenderer()
 void MeshRenderer::Initialize()
 {
 	BaseRenderer::Initialize();
+	BoneAnimator* animator = GetOwner()->GetComponent<BoneAnimator>();
+	if (animator)
+	{
+		mBoneAnimator = animator;
+	}
 }
 
 void MeshRenderer::Update()
@@ -58,6 +65,11 @@ void MeshRenderer::Render()
 
 	if (GetModel() != nullptr)
 	{
+		if (mBoneAnimator)
+		{
+			GetModel()->SetFrameAnimationVector(&(mBoneAnimator->GetFrameAnimationData()));
+		}
+
 		GetModel()->Bind_Render();
 	}
 	else

--- a/Engine_SOURCE/MeshRenderer.h
+++ b/Engine_SOURCE/MeshRenderer.h
@@ -4,7 +4,7 @@
 #include "Material.h"
 
 
-
+class BoneAnimator;
 class MeshRenderer : public BaseRenderer
 {
 public:
@@ -16,4 +16,9 @@ public:
 	virtual void FixedUpdate() final;
 	virtual void PrevRender() final;
 	virtual void Render() final;
+
+	void SetBoneAnimator(BoneAnimator* aniamtor) { mBoneAnimator = aniamtor; }
+
+private:
+	BoneAnimator* mBoneAnimator;
 };

--- a/Engine_SOURCE/Model.cpp
+++ b/Engine_SOURCE/Model.cpp
@@ -13,7 +13,6 @@ namespace fs = std::filesystem;
 
 Model::Model()
 	: Resource(eResourceType::Model)
-	, mOwner(nullptr)
 	, mStructure(nullptr)
 	, mAssimpImporter{}
 	, mNodes{}
@@ -184,8 +183,14 @@ void Model::Bind_Render(bool bindMaterial)
 		mVariableMaterials[i] == nullptr ? mMaterials[i]->Clear() : mVariableMaterials[i]->Clear();
 	}
 
+	mFrameAnimationVector = nullptr;
 	mStructure->Clear();
 	boneMat.clear();
+}
+
+void Model::SetFrameAnimationVector(const std::map<std::wstring, aiMatrix4x4>* animationVector)
+{
+	mFrameAnimationVector = animationVector;
 }
 
 
@@ -547,6 +552,15 @@ void Model::recursiveProcessBoneMatrix(aiMatrix4x4 matrix, const std::wstring& n
 {
 	const ModelNode* modelNode = FindNode(nodeName);
 	aiMatrix4x4 transform = modelNode->mTransformation;
+
+	if (mFrameAnimationVector)
+	{
+		auto iter = mFrameAnimationVector->find(nodeName);
+		if (iter != mFrameAnimationVector->end())
+		{
+			transform = iter->second;
+		}
+	}
 
 	matrix = matrix * transform;
 

--- a/Engine_SOURCE/Model.h
+++ b/Engine_SOURCE/Model.h
@@ -85,12 +85,13 @@ public:
 public:
 	GETSET(const std::wstring&, mRootNodeName, RootNodeName)
 	GETSET(const std::wstring&, mCurDirectoryPath, CurDirectoryPath)
-	GETSET(GameObj*, mOwner, Owner)
 	GETSET(Model*, mParentModel, ParentModel)
 	GETSET(const std::wstring&, mParentTargetBone, ParentTargetBone)
 	GETSET(const std::wstring&, mTargetBone, TargetBone)
 	GETSET(math::Vector3, mOffsetRotation, OffsetRotation)
 	const std::vector<Mesh*>& GetMeshes() { return mMeshes; }
+
+	void SetFrameAnimationVector(const std::map<std::wstring, aiMatrix4x4>* animationVector);
 private:
 	Assimp::Importer mAssimpImporter;
 
@@ -104,8 +105,9 @@ private:
 
 	std::vector<std::vector<TextureInfo>> mTextures;
 
+	const std::map<std::wstring, aiMatrix4x4>* mFrameAnimationVector;
+
 	StructedBuffer* mStructure;
-	GameObj* mOwner;
 
 	std::wstring mRootNodeName;
 	std::wstring mCurDirectoryPath;

--- a/Engine_SOURCE/Player.cpp
+++ b/Engine_SOURCE/Player.cpp
@@ -119,6 +119,8 @@ void Player::Initialize()
 
 	rigid->SetRigidDynamicLockFlag(PxRigidDynamicLockFlag::Enum::eLOCK_ANGULAR_Z, true);
 	rigid->SetRigidDynamicLockFlag(PxRigidDynamicLockFlag::Enum::eLOCK_ANGULAR_X, true);
+
+	mr->SetBoneAnimator(nullptr);
 }
 
 void Player::Update()
@@ -149,10 +151,11 @@ void Player::FixedUpdate()
 		i->FixedUpdate();
 	}
 
-
+	Transform* transform = GetComponent<Transform>();
+	math::Matrix playerWorldMatirx = transform == nullptr ? math::Matrix::Identity : transform->GetWorldMatrix();
 	for (auto i : mParts)
 	{
-		i->GetComponent<Transform>()->SetWorldMatrix(GetComponent<Transform>()->GetWorldMatrix());
+		i->GetComponent<Transform>()->SetWorldMatrix(playerWorldMatirx);
 	}
 
 	//mMarioCap->FixedUpdate();

--- a/Engine_SOURCE/ScenePlay.cpp
+++ b/Engine_SOURCE/ScenePlay.cpp
@@ -112,7 +112,16 @@ void ScenePlay::Initialize()
 	{
 		Goomba* goomba = object::Instantiate<Goomba>(eLayerType::Monster, this);
 		goomba->SetPos(Vector3(5.f, 10.f, 0.f));
+
+		//goomba->SetMonsterState(Monster::eMonsterState::Hit);
 	}	
+
+	{
+		Goomba* goomba = object::Instantiate<Goomba>(eLayerType::Monster, this);
+		goomba->SetPos(Vector3(15.f, 10.f, 0.f));
+
+		goomba->SetMonsterState(Monster::eMonsterState::Hit);
+	}
 
 	{
 		CubeMapHDR* cubeMap = object::Instantiate<CubeMapHDR>(eLayerType::CubeMap, this);


### PR DESCRIPTION
[ Modify ]

AnimationClip.cpp

1. {LINE 349}노드계층의 이름의 Armatuar_ 태그를 붙혀두었습니다. ( 이는 모델의 본 정보계산에서 검색하는데 사용될 것입니다. )

2. {LINE 219} 자신을 호출하는 애니메이터에 현재 노드정보를 insert 합니다.

BoneAnimator.cpp

1. {LINE 46} 프레임 애니메이션 정보를 담는 map자료를 업데이트이전 비워둡니다.
2. {LINE 175} BoneAnimator::GetAnimationNodeTransform 함수 구현
3. {LINE 184}BoneAnimator::AddNodeTransform 함수 구현
4. {LINE 193} BoneAnimator::DeleteNodeTransform 함수 구현

BoneAnimaotr.h
1. {LINE 6} assimp에서 제공되는 클래스를 사용하기위해 관련 헤더를 인클루드 하였습니다.
2. {LINE 39} AnimationClip* GetAnimationClip 함수 선언
3. {LINE 41} GetFrameAnimationData 함수 선언
4. {LINE 42} GetAnimationNodeTransform 함수 선언
5. {LINE 43} AddNodeTransform 함수 선언
6. {LINE 44} DeleteNodeTransform 함수 선언
7. {LINE 54} mFrameAnimationVector 변수 선언

MarioCap.cpp
1. {LINE 81} MeshRenderer 의 멤버 변수인 BoneAnimator 를 nullptr 로 세팅하였습니다.

Marioparts.cpp
1. {LINE 37} MeshRenderer 의 멤버 변수인 BoneAnimator 를 nullptr 로 세팅하였습니다.

MeshRenderer.cpp
1. {LINE 23} 초기화할때 멤버변수 mBoneAnimator 를 Owner 의 애니메이터로 초기화합니다.
2. {LINE 68} 애니메이션의 프레임에니메이션정보를 모델에 FrameAnimationVector 에 초기화 합니다.

MeshRenderer.h
1. {LINE 23} mBoneAnimator 맴버 변수를 추가하였습니다.
2. {LINE 20} mBoneAnimator 를 초기화하는 함수 선언, 구현 부

Model.cpp

1. {LINE 191} SetFrameAnimationVector 함수 구현
2. {LINE 556} 계층정보를 재귀적으로 호출하여 행렬을 구성하는 도중 현재 프레임 애니메이션 정보가 있다면 현 계층정보를 애니메이션 정보로 대입합니다.

Model.h

1. {LINE 108} mFrameAnimationVector 멤버 변수 추가
2. {LINE 94} SetFrameAnimationVector 함수 선언

Player.cpp

1. {LINE 123} MeshRenderer 의 멤버 변수인 BoneAnimator 를 nullptr 로 세팅하였습니다.

2. {LINE 154} Transform* 변수와 월드매트릭스를 캐싱하여 사용합니다.

ScenePlay.cpp

1. {LINE 120 } 굼바의 애니메이션을 테스트하기 위해 작성되었습니다. 새로운 굼바를 할당합니다